### PR TITLE
bootloader_message: allow devices to override

### DIFF
--- a/bootloader_message/Android.mk
+++ b/bootloader_message/Android.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ifneq ($(BOARD_PROVIDES_BOOTLOADER_MESSAGE),true)
+
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
@@ -23,3 +25,5 @@ LOCAL_CFLAGS := -Werror
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 include $(BUILD_STATIC_LIBRARY)
+
+endif


### PR DESCRIPTION
* Some devices do not have a misc partition or something that can be
  used as a surrogate, but we still need a place to write the recovery
  commands to. In these cases, allow a device tree to override the
  default aosp behavior and instead do such things as use a file on
  /cache to handle this.

* NOTE: Your device must also specify BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE
  if you plan to use /cache/recovery/command as this is used to tell
  android to use this dedicated /cache partition rather than symlinking
  it to /data/cache

Change-Id: I254c28a1e4d9b8df9c0e5d9ebcc087b58a45d5a3